### PR TITLE
Don't crash Notepad++ when running plugin commands with multiple selections

### DIFF
--- a/src/NppJsonViewer/NPPJSONViewer.vcxproj
+++ b/src/NppJsonViewer/NPPJSONViewer.vcxproj
@@ -242,4 +242,46 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <PropertyGroup>
+    <!-- Default values for debugging so it start correct version of Notepad++
+         $(ProgramW6432) and $(MSBuildProgramFiles32) points to the 64 and 32 bit "Program Files" directories -->
+    <NppPath64 Condition="'$(NppPath64)' == ''">$(ProgramW6432)\Notepad++</NppPath64>
+    <NppPath32 Condition="'$(NppPath32)' == ''">$(MSBuildProgramFiles32)\Notepad++</NppPath32>
+  </PropertyGroup>
+  <!-- This block here is part of molsonkiko's (thus far unsuccessful) efforts to start up Notepad++ as soon as the plugin is done building.
+  In JsonTools (and all the other plugins based on the same plugin C# plugin template), when you build the plugin, it does the following:
+  1. automatically copies the plugin to the JsonTools plugin folder for the appropriate Notepad++ installation (this is done by the Target Name="CopyBin" below)
+  2. starts up that Notepad++ installation, so that you can immediately start debugging Notepad++ with the version of the plugin you just compiled.
+  <Choose>
+    <When Condition="'$(Platform)' == 'x64'">
+      <ItemGroup>
+        <NPP_EXE Include="$(NppPath64)\notepad++.exe" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <NPP_EXE Include="$(NppPath32)\notepad++.exe" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  -->
+  <Target Name="CopyBin" DependsOnTargets="Build" AfterTargets="Build">
+    <!-- copy over the plugin DLL to the Notepad++ directory.
+    Otherwise Notepad++ will just load without the plugin. -->
+    <ItemGroup>
+      <RELEASE64 Include="..\Build\Bin\Release\x64\NPPJSONViewer.dll" />
+      <DEBUG64 Include="..\Build\Bin\Debug\x64\NPPJSONViewer.dll" />
+      <RELEASE32 Include="..\Build\Bin\Release\Win32\NPPJSONViewer.dll" />
+      <DEBUG32 Include="..\Build\Bin\Debug\Win32\NPPJSONViewer.dll" />
+      <NPP64BIT Include="$(NppPath64)\plugins\NPPJSONViewer" />
+      <NPP32BIT Include="$(NppPath32)\plugins\NPPJSONViewer" />
+    </ItemGroup>
+    <MakeDir Directories="@(NPP64BIT)" Condition=" '$(Platform)' == 'x64' " />
+    <MakeDir Directories="@(NPP32BIT)" Condition=" '$(Platform)' == 'Win32' " />
+    <!-- copy the plugin DLL to NPP plugin dir -->
+    <Copy SourceFiles="@(RELEASE64)" Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' " DestinationFolder="@(NPP64BIT)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(RELEASE32)" Condition=" '$(Configuration)|$(Platform)' == 'Release|Win32' " DestinationFolder="@(NPP32BIT)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(DEBUG64)" Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' " DestinationFolder="@(NPP64BIT)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(DEBUG32)" Condition=" '$(Configuration)|$(Platform)' == 'Debug|Win32' " DestinationFolder="@(NPP32BIT)" SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/src/NppJsonViewer/NppJsonPlugin.cpp
+++ b/src/NppJsonViewer/NppJsonPlugin.cpp
@@ -154,14 +154,26 @@ void NppJsonPlugin::ToggleMenuItemState(int nCmdId, bool bVisible)
     ::SendMessage(m_NppData._nppHandle, NPPM_SETMENUITEMCHECK, static_cast<WPARAM>(nCmdId), bVisible);
 }
 
-void NppJsonPlugin::ConstructJsonDlg()
+bool NppJsonPlugin::ConstructJsonDlg()
 {
+    int whichScintilla = -1;
+    ::SendMessage(m_NppData._nppHandle, NPPM_GETCURRENTSCINTILLA, 0, reinterpret_cast<LPARAM>(&whichScintilla));
+    if (whichScintilla == -1)
+        return FALSE;
+    HWND   hScintilla  = whichScintilla == 0 ? m_NppData._scintillaMainHandle : m_NppData._scintillaSecondHandle;
+    size_t nSelections = ::SendMessage(hScintilla, SCI_GETSELECTIONS, 0, 0);
+    if (nSelections > 1)
+    {
+        ::MessageBox(NULL, L"JSON-Viewer does not currently support multiple selections.", L"JSON-Viewer does not support multiple selections", MB_OK | MB_ICONERROR);
+        return FALSE;
+    }
     if (!m_pJsonViewDlg)
     {
         ConstructSetting();
         auto nCmdId    = m_shortcutCommands.GetCommandID(CallBackID::SHOW_DOC_PANEL);
         m_pJsonViewDlg = std::make_unique<JsonViewDlg>(reinterpret_cast<HINSTANCE>(m_hModule), m_NppData, m_bNppReady, nCmdId, m_pSetting);
     }
+    return TRUE;
 }
 
 void NppJsonPlugin::ConstructSetting()
@@ -175,7 +187,8 @@ void NppJsonPlugin::ConstructSetting()
 
 void NppJsonPlugin::ShowJsonDlg()
 {
-    ConstructJsonDlg();
+    if (!ConstructJsonDlg())
+        return;
 
     if (m_pJsonViewDlg)    // Hope it is constructed by now.
     {
@@ -186,7 +199,8 @@ void NppJsonPlugin::ShowJsonDlg()
 
 void NppJsonPlugin::FormatJson()
 {
-    ConstructJsonDlg();
+    if (!ConstructJsonDlg())
+        return;
 
     if (m_pJsonViewDlg)    // Hope it is constructed by now.
     {
@@ -196,7 +210,8 @@ void NppJsonPlugin::FormatJson()
 
 void NppJsonPlugin::CompressJson()
 {
-    ConstructJsonDlg();
+    if (!ConstructJsonDlg())
+        return;
 
     if (m_pJsonViewDlg)    // Hope it is constructed by now.
     {
@@ -206,7 +221,8 @@ void NppJsonPlugin::CompressJson()
 
 void NppJsonPlugin::SortJsonByKey()
 {
-    ConstructJsonDlg();
+    if (!ConstructJsonDlg())
+        return;
 
     if (m_pJsonViewDlg)    // Hope it is constructed by now.
     {

--- a/src/NppJsonViewer/NppJsonPlugin.h
+++ b/src/NppJsonViewer/NppJsonPlugin.h
@@ -74,8 +74,9 @@ private:
     void InitConfigPath();
 
     void ToggleMenuItemState(int nCmdId, bool bVisible);
-
-    void ConstructJsonDlg();
+    // return FALSE if for whatever reason we cannot attempt to parse the document
+    //     (currently the only reason for this would be if there are multiple selections)
+    bool ConstructJsonDlg();
     void ConstructSetting();
 
     void ShowJsonDlg();

--- a/src/UtilityLib/StringHelper.cpp
+++ b/src/UtilityLib/StringHelper.cpp
@@ -1,5 +1,6 @@
-#include "StringHelper.h"
 #include <regex>
+
+#include "StringHelper.h"
 
 std::string StringHelper::ReplaceAll(const std::string &str, const std::string &search, const std::string &replace)
 {

--- a/src/UtilityLib/Utility.h
+++ b/src/UtilityLib/Utility.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 #include <Windows.h>
-#include <optional>
 
 class CUtility
 {

--- a/tests/UnitTest/JsonHandlerTest.cpp
+++ b/tests/UnitTest/JsonHandlerTest.cpp
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <vector>
 #include <string>
-#include <memory>
 
 #include "JsonHandler.h"
 


### PR DESCRIPTION
## FIX

This would fix #197 .

Previously, running any plugin command other than `Settings` or `About` would cause Notepad++ to crash if the user had multiple selections. This commit would fix this issue by, whenever they use a single-selection-only command, informing the user and bailing out early if they have multiple selections.

You may not agree with this specific approach to fixing this bug, but I would argue that an easily reproduced issue that is guaranteed to cause a Notepad++ crash should be treated with the highest urgency. I won't be offended if you reject this PR, so long as you promptly fix the issue it is intended to address.

### HOW THE FIX WORKS

Quite simple; before running any action that involves parsing JSON (these all seem to call the `ConstructJsonDlg` method), we check if the user has multiple selections in the current document. If they do, we show them a message box saying that JSON Viewer doesn't support multiple selections, and return early.

If the user has only one selection, we run the plugin command normally.

## NEW AFTER-BUILD ACTION

Add a new after-build action to `NPPJSONViewer.vcxproj` that creates an `NPPJSONViewer` plugin directory (if one doesn't already exist) in the appropriate Notepad++ installation (`%ProgramFiles%\Notepad++` for an x64 build or `%ProgramFiles(x86)%\Notepad++` for a Win32 build) and then copies the `NPPJSONViewer.dll` that you just built into that plugin folder.

I also tried to add another action that would run that Notepad++ installation afterwards, but I couldn't figure out how to do that.